### PR TITLE
refactor:navbar

### DIFF
--- a/src/containers/home/index.js
+++ b/src/containers/home/index.js
@@ -10,6 +10,7 @@ import * as walletActions from '../../actions/wallet'
 import * as contractActions from '../../actions/contract'
 import * as walletSelectors from '../../reducers/wallet'
 import * as contractSelectors from '../../reducers/contract'
+import { NavHeader } from '../nav-header'
 import { ContractDisplayList } from '../contract-display-list'
 import { objMap } from '../../utils/functional'
 import { renderIf } from '../../utils/react-redux'
@@ -84,25 +85,7 @@ class Home extends PureComponent {
           loading: <span>loading</span>,
           done: contracts.data && (
             <div className="flex-container-main" key={contract._id}>
-              <div className="flex-container-main-menu">
-                <div className="flex-container-main-menu-items">
-                  <div className="flex-container-main-menu-items-item flex-container-main-menu-items-kleros">
-                    KLEROS
-                  </div>
-                  <div
-                    onClick={redirect('/profile', history)}
-                    className="flex-container-main-menu-items-item"
-                  >
-                    Profile
-                  </div>
-                  <div
-                    className="flex-container-main-menu-items-item"
-                    onClick={redirect('/contracts/new', history)}
-                  >
-                    New contract
-                  </div>
-                </div>
-              </div>
+              <NavHeader history={history} />
               <ContractDisplayList
                 randomSeed={randomSeed}
                 contracts={contracts}

--- a/src/containers/nav-header/index.js
+++ b/src/containers/nav-header/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { redirect } from '../../utils/contract'
+
+export const NavHeader = ({history}) => (
+  <div className="flex-container-main-menu">
+    <div className="flex-container-main-menu-items">
+      <div
+        className="flex-container-main-menu-items-item flex-container-main-menu-items-kleros"
+        onClick={redirect('/', history)}
+      >
+        KLEROS
+      </div>
+      <div className="flex-container-main-menu-items-item"
+           onClick={redirect('/profile', history)}>
+        Profile
+      </div>
+      <div
+        className="flex-container-main-menu-items-item"
+        onClick={redirect('/contracts/new', history)}
+      >
+        New contract
+      </div>
+    </div>
+  </div>)

--- a/src/containers/profile/index.js
+++ b/src/containers/profile/index.js
@@ -14,6 +14,7 @@ import { objMap } from '../../utils/functional'
 import { renderIf } from '../../utils/react-redux'
 import Identicon from '../../components/identicon'
 import { redirect, shortAddress } from '../../utils/contract'
+import { NavHeader } from '../nav-header'
 
 import './profile.css'
 
@@ -86,25 +87,7 @@ class Profile extends PureComponent {
           loading: <span>loading</span>,
           done: contracts.data && (
             <div className="flex-container-main" key={contract._id}>
-              <div className="flex-container-main-menu">
-                <div className="flex-container-main-menu-items">
-                  <div
-                    className="flex-container-main-menu-items-item flex-container-main-menu-items-kleros"
-                    onClick={() => redirect('/', history)}
-                  >
-                    KLEROS
-                  </div>
-                  <div className="flex-container-main-menu-items-item">
-                    Profile
-                  </div>
-                  <div
-                    className="flex-container-main-menu-items-item"
-                    onClick={() => redirect('/contracts/new', history)}
-                  >
-                    New contract
-                  </div>
-                </div>
-              </div>
+              <NavHeader history={history} />
               <div className="flex-container">
                 <div className="flex-item wide grow">
                   <div className="type">Profile</div>

--- a/src/utils/contract.js
+++ b/src/utils/contract.js
@@ -7,7 +7,6 @@
  */
 
 export const redirect = (url, history, ...args) => () => {
-  console.log("I am here!");
   if (!args || args.length === 0) history.push(url)
   else {
     const allArgs = args.reduce((acc, arg) => `${acc}/${arg}`)

--- a/src/utils/contract.js
+++ b/src/utils/contract.js
@@ -7,6 +7,7 @@
  */
 
 export const redirect = (url, history, ...args) => () => {
+  console.log("I am here!");
   if (!args || args.length === 0) history.push(url)
   else {
     const allArgs = args.reduce((acc, arg) => `${acc}/${arg}`)


### PR DESCRIPTION
This refactors the navbar shared between `home` and `profile` creating a reusable component. 

It fixes an issue with creating a contract on the profile page - the util method cannot exist in an arrow function.

It provides a way to return to the home page  in both views.